### PR TITLE
Update to denoland/setup-deno

### DIFF
--- a/.github/workflows/vno.test.yml
+++ b/.github/workflows/vno.test.yml
@@ -12,13 +12,13 @@ jobs:
 
     strategy:
       matrix:
-       deno-version: ["v1.10.2"]
+       deno-version: ["v1.x"]
 
     steps:
     - name: Git Checkout Deno Mod
       uses: actions/checkout@v2
     - name: Use Deno Version ${{ matrix.deno-version }}
-      uses: denolib/setup-deno@v2.3.0
+      uses: denoland/setup-deno@v1
       with:
        deno-version: ${{ matrix.deno-version }}
     - name: Build Vno Mod


### PR DESCRIPTION
This will use latest 1.x version of Deno to be able to build latest commits like #117 