### PR TITLE
Update dependencies to latest - Fix getIterator error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,17 @@
 //vscode import settings for default formatter (typescript && js)
-
+// using official denoland extension
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": true,
-  "[typescript]": {
-    "editor.defaultFormatter": "denoland.vscode-deno"
+  "deno.unstable": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true,
+    "source.organizeImports": true
   },
-  "[javascript]": {
-    "editor.defaultFormatter": "denoland.vscode-deno"
+  "editor.defaultFormatter": "denoland.vscode-deno",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false,
+  "deno.suggest.imports.hosts": {
+    "https://deno.land": true
   }
 }

--- a/core/cli/dev.ts
+++ b/core/cli/dev.ts
@@ -1,22 +1,19 @@
 import { Application, path, send } from "../utils/deps.ts";
 import { WebSocketClient, WebSocketServer } from "../utils/deps.ts";
 import * as print from "./stdout.ts";
-import { exec } from "../utils/deps.ts";
 import { watchAndRebuild } from "./liveRebuild.ts";
-import { event } from "../utils/events.ts"
-
-
+import { event } from "../utils/events.ts";
 
 export const server: Application = new Application();
 
 export const runDevServer = async function (port: number, hostname: string) {
   const wss = new WebSocketServer(8080);
   wss.on("connection", function (ws: WebSocketClient) {
-    ws.send('[LiveReload is watching...');
+    ws.send("[LiveReload is watching...");
     // create event listener that listens for "buildDone" event
     const reloadWindow = () => {
       console.log("[back to you Client!]");
-      ws.send('reload window');
+      ws.send("reload window");
       event.removeListener("buildDone", reloadWindow);
     };
 
@@ -26,7 +23,6 @@ export const runDevServer = async function (port: number, hostname: string) {
       console.log(message);
     });
   });
-
 
   //server route handler
   server.use(async (ctx, next) => {
@@ -60,7 +56,7 @@ export const runDevServer = async function (port: number, hostname: string) {
   server.addEventListener("listen", () => {
     print.LISTEN(port, hostname);
     if (running === false) {
-      watchAndRebuild({ ssr: false }); 
+      watchAndRebuild({ ssr: false });
       running = true;
     }
   });

--- a/core/dts/factory.d.ts
+++ b/core/dts/factory.d.ts
@@ -87,7 +87,6 @@ export interface Config {
      * preferred host
      * default: "0.0.0.0"
      */
-
   };
 }
 export declare namespace Vue {

--- a/core/factory/Factory.ts
+++ b/core/factory/Factory.ts
@@ -128,7 +128,7 @@ export default class Factory {
     const decoder = new TextDecoder("utf-8");
 
     const styles = decoder.decode(
-      Deno.readFileSync(Deno.cwd()+"/vno-build/style.css"),
+      Deno.readFileSync(Deno.cwd() + "/vno-build/style.css"),
     );
 
     Deno.writeTextFileSync(
@@ -188,6 +188,6 @@ export default class Factory {
   // added router 9/21/21
   get router() {
     if (this._router) return this._router;
-    return "^4.0.0-0"
+    return "^4.0.0-0";
   }
 }

--- a/core/lib/resolver.ts
+++ b/core/lib/resolver.ts
@@ -9,18 +9,18 @@ export const _script: Resolve.Source = async function (data, path, tsCheck) {
   if (typeof data === "string") {
     throw new TypeError("invalid arguments");
   }
-//"^" beginning of line
-//"\s" looks for whitespace
-//looking for export
-//"*" 0 or more
-//() capture group: please find any in capture group and also allow you to remember it refer
-//to it by $1,2,3 etc.. like postgres $1, $2 for points you want to make dynamic.
-//so later you can change the $1 that you can find and replace
+  //"^" beginning of line
+  //"\s" looks for whitespace
+  //looking for export
+  //"*" 0 or more
+  //() capture group: please find any in capture group and also allow you to remember it refer
+  //to it by $1,2,3 etc.. like postgres $1, $2 for points you want to make dynamic.
+  //so later you can change the $1 that you can find and replace
   const start = utils.indexOfRegExp(/^\s*(export)/, data);
   const end = data.lastIndexOf("}");
 
   const trimmed = data.slice(start + 1, end).join("\n");
-//grabed trim a string of key:value pairs and putting it inside object
+  //grabed trim a string of key:value pairs and putting it inside object
   let script = tsCheck
     ? await typescriptCompile(`({ ${trimmed} })`, path)
     : trimmed as string;
@@ -78,7 +78,6 @@ export const _dependants: Resolve.Attrs = function (curr, arr, storage, queue) {
     }
   }
 };
-
 
 //vno struggles with third party imports in component file.
 //this collects all potential imports.  inserts them at the top of the bundle - not working perfectly

--- a/core/ssg/dev.ts
+++ b/core/ssg/dev.ts
@@ -1,10 +1,10 @@
 import {
   WebSocketClient,
   WebSocketServer,
-} from "https://deno.land/x/websocket@v0.1.2/mod.ts";
-import { Application, send } from "https://deno.land/x/oak@v7.7.0/mod.ts";
-import { EventEmitter } from "https://deno.land/std@0.100.0/node/events.ts";
-import * as path from "https://deno.land/std@0.99.0/path/mod.ts";
+} from "https://deno.land/x/websocket@v0.1.3/mod.ts";
+import { Application, send } from "https://deno.land/x/oak@v10.0.0/mod.ts";
+import { EventEmitter } from "https://deno.land/std@0.117.0/node/events.ts";
+import * as path from "https://deno.land/std@0.117.0/path/mod.ts";
 import { debounce } from "./utils.ts";
 import { generate } from "./generate.ts";
 

--- a/core/utils/deps.ts
+++ b/core/utils/deps.ts
@@ -1,17 +1,17 @@
 // deno std library
-export * as fs from "https://deno.land/std@0.83.0/fs/mod.ts";
-export * as path from "https://deno.land/std@0.83.0/path/mod.ts";
-export * as colors from "https://deno.land/std@0.83.0/fmt/colors.ts";
-export * as http from "https://deno.land/std@0.83.0/http/mod.ts";
-export { v4 } from "https://deno.land/std@0.88.0/uuid/mod.ts"; //uuid generator
+export * as fs from "https://deno.land/std@0.117.0/fs/mod.ts";
+export * as path from "https://deno.land/std@0.117.0/path/mod.ts";
+export * as colors from "https://deno.land/std@0.117.0/fmt/colors.ts";
+export * as http from "https://deno.land/std@0.117.0/http/mod.ts";
+export { v4 } from "https://deno.land/std@0.117.0/uuid/mod.ts"; //uuid generator
 export {
   assertEquals,
   assertNotEquals,
-} from "https://deno.land/std@0.83.0/testing/asserts.ts"; // testing library
+} from "https://deno.land/std@0.117.0/testing/asserts.ts"; // testing library
 import {
   WebSocketClient,
   WebSocketServer,
-} from "https://deno.land/x/websocket@v0.1.1/mod.ts";
+} from "https://deno.land/x/websocket@v0.1.3/mod.ts";
 export { WebSocketServer };
 export type { WebSocketClient };
 
@@ -21,11 +21,12 @@ export {
   Context,
   Router,
   send,
-} from "https://deno.land/x/oak@v6.5.0/mod.ts";
-export { superoak } from "https://deno.land/x/superoak@4.0.0/mod.ts"; // testing lib for oak
+} from "https://deno.land/x/oak@v10.0.0/mod.ts";
+export { superoak } from "https://deno.land/x/superoak@4.5.0/mod.ts"; // testing lib for oak
 
 // third-party
-import _ from "https://cdn.skypack.dev/lodash"; // lodash
+import * as _ from "https://deno.land/x/lodash@4.17.15-es/lodash.js"; // lodash
+
 import ProgressBar from "https://deno.land/x/progress@v1.2.3/mod.ts";
 import { exec } from "https://deno.land/x/exec/mod.ts";
 export { _, exec, ProgressBar };
@@ -35,5 +36,5 @@ export { compile as scssCompiler } from "https://raw.githubusercontent.com/crewd
 export * as sfcCompiler from "https://denopkg.com/crewdevio/vue-deno-compiler/mod.ts";
 
 //event emitter for live reload
-import { EventEmitter } from "https://deno.land/std@0.93.0/node/events.ts";
+import { EventEmitter } from "https://deno.land/std@0.117.0/node/events.ts";
 export { EventEmitter };


### PR DESCRIPTION
Fix: 

```
error: TS2339 [ERROR]: Property 'getIterator' does not exist on type 'ReadableStream<R>'.
  return res.readable.getIterator();
```

Update the std dependencies to the latest std 0.117.0
- update other dependencies to latest as well
- update lodash to