### PR TITLE
Updated deno's std libary refs

### DIFF
--- a/core/ssg/assets.ts
+++ b/core/ssg/assets.ts
@@ -1,4 +1,4 @@
-import * as fs from "https://deno.land/std@0.83.0/fs/mod.ts";
+import * as fs from "https://deno.land/std@0.123.0/fs/mod.ts";
 import * as path from "https://deno.land/std@0.99.0/path/mod.ts";
 import { Mapped } from "./utils.ts";
 

--- a/core/ssg/components.ts
+++ b/core/ssg/components.ts
@@ -1,5 +1,5 @@
 import Vue from "https://deno.land/x/vue_js@0.0.5/mod.js";
-import * as fs from "https://deno.land/std@0.83.0/fs/mod.ts";
+import * as fs from "https://deno.land/std@0.123.0/fs/mod.ts";
 import * as vueCompiler from "https://denopkg.com/crewdevio/vue-deno-compiler/mod.ts";
 import * as path from "https://deno.land/std@0.99.0/path/mod.ts";
 import { getExport, getTags, Mapped, VueExport } from "./utils.ts";

--- a/core/ssg/utils.ts
+++ b/core/ssg/utils.ts
@@ -1,5 +1,5 @@
 import * as path from "https://deno.land/std@0.99.0/path/mod.ts";
-import * as fs from "https://deno.land/std@0.83.0/fs/mod.ts";
+import * as fs from "https://deno.land/std@0.123.0/fs/mod.ts";
 import { Language, minify } from "https://deno.land/x/minifier@v1.1.1/mod.ts";
 
 export type Mapped<T> = { [key: string]: T };

--- a/core/utils/deps.ts
+++ b/core/utils/deps.ts
@@ -1,9 +1,9 @@
 // deno std library
-export * as fs from "https://deno.land/std@0.83.0/fs/mod.ts";
-export * as path from "https://deno.land/std@0.83.0/path/mod.ts";
-export * as colors from "https://deno.land/std@0.83.0/fmt/colors.ts";
-export * as http from "https://deno.land/std@0.83.0/http/mod.ts";
-export { v4 } from "https://deno.land/std@0.88.0/uuid/mod.ts"; //uuid generator
+export * as fs from "https://deno.land/std@0.123.0/fs/mod.ts";
+export * as path from "https://deno.land/std@0.123.0/path/mod.ts";
+export * as colors from "https://deno.land/std@0.123.0/fmt/colors.ts";
+export * as http from "https://deno.land/std@0.123.0/http/mod.ts";
+export { v4 } from "https://deno.land/std@0.123.0/uuid/mod.ts"; //uuid generator
 export {
   assertEquals,
   assertNotEquals,


### PR DESCRIPTION
Replaced dependencies with the newer ones. This fix installed successfully and works for:

- deno 1.18.1
- v8 9.8.177.6
- typescript 4.5.2